### PR TITLE
mep-0001: Revision 1

### DIFF
--- a/mep-0001.md
+++ b/mep-0001.md
@@ -382,14 +382,6 @@ a function's name is changed
 </tr>
 
 <tr>
-<td>introduce a cycle</td>
-<td>
-comments are added
-</td>
-<td>Y</td>
-</tr>
-
-<tr>
 <td>introduce a syntax error</td>
 <td>
 function replaced with a call to `_add_unparsable_cell`
@@ -641,7 +633,7 @@ if __name__ == '__main__':
    add magic comments or symbols to parse the code into cells, making
    the format brittle.
 
-7. Leave comments documenting which cells are involved in syntax errors,
+7. Leave comments documenting which cells are involved in cycles,
    which names are multiply defined and by which cells, and which
    cells try to delete their refs. We can add these things later, without
    affecting compatibility, since they are just comments.


### PR DESCRIPTION
Remove the auto-generated DAG; it only made things harder to read, and ruined diffs.

Rename core to app.

Flat file, with cells defined as functions decorated with `app.cell`.

Move the version number from the module docstring to a variable.

Evaluation of format against desiderata.